### PR TITLE
List binding fix

### DIFF
--- a/cli/gen-package/src/Generate.elm
+++ b/cli/gen-package/src/Generate.elm
@@ -589,8 +589,16 @@ getArgumentUnpacker freshCount tipe value =
 
         Elm.Type.Type "List.List" [ inner ] ->
             let
+                varName =
+                    "lambdaArg" ++ String.fromInt freshCount
+
                 f =
-                    getArgumentUnpacker freshCount inner value
+                    Elm.apply (Elm.valueFrom [ "List" ] "map")
+                        [ Elm.lambdaBetaReduced varName
+                            (typeToAnnotation inner)
+                            (getArgumentUnpacker (freshCount + 1) inner)
+                        , value
+                        ]
             in
             ElmGen.list f
 

--- a/dist/gen-package.js
+++ b/dist/gen-package.js
@@ -10808,7 +10808,23 @@ var $author$project$Generate$getArgumentUnpacker = F3(
 					if (((tipe.a === 'List.List') && tipe.b.b) && (!tipe.b.b.b)) {
 						var _v3 = tipe.b;
 						var inner = _v3.a;
-						var f = A3($author$project$Generate$getArgumentUnpacker, freshCount, inner, value);
+						var varName = 'lambdaArg' + $elm$core$String$fromInt(freshCount);
+						var f = A2(
+							$author$project$Elm$apply,
+							A2(
+								$author$project$Elm$valueFrom,
+								_List_fromArray(
+									['List']),
+								'map'),
+							_List_fromArray(
+								[
+									A3(
+									$author$project$Elm$lambdaBetaReduced,
+									varName,
+									$author$project$Generate$typeToAnnotation(inner),
+									A2($author$project$Generate$getArgumentUnpacker, freshCount + 1, inner)),
+									value
+								]));
 						return $author$project$Elm$Gen$Elm$list(f);
 					} else {
 						break _v0$3;

--- a/src/Elm.elm
+++ b/src/Elm.elm
@@ -790,7 +790,7 @@ letIn : List Let.Declaration -> Expression -> Expression
 letIn decls (Compiler.Expression within) =
     let
         gathered =
-            List.foldl
+            List.foldr
                 (\(Compiler.LetDeclaration mods dec) accum ->
                     { declarations =
                         dec :: accum.declarations


### PR DESCRIPTION
If we're unpacking a list, we need to `List.map` the unpacker over the list